### PR TITLE
Fix a typo and update openssl to support OpenSSL 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["dylib"]
 
 [dependencies]
 libc = "0.2.0"
-openssl = "0.9.17"
+openssl = "0.10.29"
 toml = "0.4"
 uuid = { version = "0.5", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The Windows Hello dialog appears many times with meaningless message of "PIN inc
 
 ## Internals
 
-Windows Hello maintains RSA key-pairs for each Windows user in its TMP hardware, and tells success of authentication by signing given contents by the private key.
+Windows Hello maintains RSA key-pairs for each Windows user in its TPM hardware, and tells success of authentication by signing given contents by the private key.
 To utilize its API, "WSL Hello sudo" contains small Windows CLI apps that return public key and singned signature of given content.
 On the other hand, the PAM module of "WSL Hello sudo" remembers the public keys of each Windows user who corresponds to each Linux user.
 So, the PAM module authenticates the given Linux user by the following process.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -235,7 +235,7 @@ fn authenticate_via_hello(pamh: *mut pam_handle_t) -> Result<i32, HelloAuthentic
         .map_err(|e| HelloAuthenticationError::OpenSSLError(e))?;
 
     match verifier
-        .finish(&signature)
+        .verify(&signature)
         .map_err(|e| HelloAuthenticationError::OpenSSLError(e))?
     {
         true => Ok(PAM_SUCCESS),


### PR DESCRIPTION
Tested on Windows 10 2004(19041.264) and Ubuntu 20.04 on WSL1 and WSL2.
