### PR TITLE
feat: support and auto-detect custom /c mountpoints

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,8 +41,19 @@ if [ ! -e build/pam_wsl_hello.so ] || \
 fi
 
 MNT=/mnt/c
+
+if [ -f "/etc/wsl.conf" ]; then
+  # Get value specified in the form of 'root = /some/path/'
+  WSL_CONF_ROOT="$(cat /etc/wsl.conf | sed -n "s/^[[:space:]]*root[[:space:]]*=\(.*\)/\1/p")"
+  # Trim path
+  WSL_CONF_ROOT="$(echo $WSL_CONF_ROOT | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  if [ -n "$WSL_CONF_ROOT" ]; then
+    MNT="${WSL_CONF_ROOT}c"
+  fi
+fi
+
 if [[ ! -e "${MNT}" ]]; then
-  echo "'/mnt/c' is not found. Please input your mount point of C drive to invoke Windows commands."
+  echo "'$MNT' was not found. Please input the mount point of your C drive to invoke Windows commands."
   echo -n ": "
   read MNT
 fi
@@ -106,6 +117,7 @@ if [ ! -e "/etc/pam_wsl_hello/config" ] || prompt_yn "'/etc/pam_wsl_hello/config
   set -x
   sudo touch /etc/pam_wsl_hello/config
   sudo echo "authenticator_path = \"$PAM_WSL_HELLO_WINPATH/WindowsHelloAuthenticator/WindowsHelloAuthenticator.exe\"" | sudo tee /etc/pam_wsl_hello/config
+  sudo echo "win_mnt = \"$MNT\"" | sudo tee -a /etc/pam_wsl_hello/config
 else
   echo "skip creation of '/etc/pam_wsl_hello/config'"
 fi


### PR DESCRIPTION
fix #9

- if an [`/etc/wsl.conf` config file](https://docs.microsoft.com/en-US/windows/wsl/wsl-config#configure-per-distro-launch-settings-with-wslconf) exists, the install script now tries to check and use its `root` value.  
Comments beginning with `#` are ignored and indentation/whitespace should work fine I think

- `$MNT` (whether it's the default `/mnt/c`, `${WSL_CONF_ROOT}c` or some custom mount setup specified during the install process) is now stored as `win_mnt` in `/etc/pam_wsl_hello/config`

- the Rust code uses that value as current directory when spawning the Authenticator instead of always using `/mnt/c` and throwing on other setups

Feel free to adjust or critique as you wish – I never have used Rust before so I was a bit stumbling in the dark throughout this... But it compiles and works 😅

Tested on Ubuntu 20.04 / WSL2