### PR TITLE
Fix warning that pointer doesn't outlive temporary CString

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -48,8 +48,12 @@ pub fn pam_sm_authenticate(
 
 fn get_user(pamh: *mut pam_handle_t, prompt: Option<&str>) -> Result<Cow<str>, i32> {
     let mut c_user: *const c_char = ptr::null();
+    let tmp_prompt_str: CString;
     let c_prompt = match prompt {
-        Some(prompt_str) => CString::new(prompt_str).unwrap().as_ptr(),
+        Some(prompt_str) => {
+            tmp_prompt_str = CString::new(prompt_str).unwrap();
+            tmp_prompt_str.as_ptr()
+        },
         None => ptr::null(),
     };
     let err;


### PR DESCRIPTION
Fixes a warning that auth.rs is retrieving the inner pointer of a temporary CString; extends the life of the CString throughout the`get_user` function.

```
warning: getting the inner pointer of a temporary `CString`
  --> src/auth.rs:53:63
   |
53 |         Some(prompt_str) => CString::new(prompt_str).unwrap().as_ptr(),
   |                             --------------------------------- ^^^^^^ this pointer will be invalid
   |                             |
   |                             this `CString` is deallocated at the end of the statement, bind it to a variable to extend its lifetime
   |
   = note: `#[warn(temporary_cstring_as_ptr)]` on by default
   = note: pointers do not have a lifetime; when calling `as_ptr` the `CString` will be deallocated at the end of the statement because nothing is referencing it as far as the type system is concerned
   = help: for more information, see https://doc.rust-lang.org/reference/destructors.html
```