### PR TITLE
feat: move hello to foreground once window exists

### DIFF
--- a/win_components/WindowsHelloAuthenticator/WindowsHelloAuthenticator/Program.cs
+++ b/win_components/WindowsHelloAuthenticator/WindowsHelloAuthenticator/Program.cs
@@ -95,7 +95,7 @@ namespace WindowsHelloAuthenticator
             var buf = CryptographicBuffer.ConvertStringToBinary(contentToSign, BinaryStringEncoding.Utf8);
             
             var tokenSource = new CancellationTokenSource();
-            FocusHelloWindow(tokenSource.Token);
+            _ = FocusHelloWindow(tokenSource.Token);
             
             var signRes = await key.Credential.RequestSignAsync(buf);
             


### PR DESCRIPTION
This checks for the existence of the Windows Hello window (className `Credential Dialog Xaml Host`) and moves it to the foreground once it is found.

~~Not the optimal solution yet, as this happens only once per auth process. If the authentication fails (which sometimes happens for whatever reason, #1), the Hello prompt is recreated behind the Terminal and this time stays there as the `FocusHelloWindow` task has already returned.~~

~~A more comprehensive solution would require some form of AutomationEventHandler or usage of the Win32 window hook API, but that's nothing I can dig into right now and even without that, this is already a massive UX improvement.~~

fix #4