### PR TITLE
fix: quote hello_winpath in uninstall.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -165,7 +165,7 @@ if [ ! -e "uninstall.sh" ] || prompt_yn "'uninstall.sh' already exists. Overwrit
     sudo pam-auth-update --remove "${PAM_CONFIG_NAME}"
     sudo rm "${PAM_CONFIG}"
   fi
-  rm -rf ${PAM_WSL_HELLO_WINPATH}
+  rm -rf "${PAM_WSL_HELLO_WINPATH}"
 EOS
   chmod +x uninstall.sh
 else


### PR DESCRIPTION
Just noticed that the path to the Windows install directory isn't quoted in the `uninstall.sh` file.
Because of this, the directory isn't removed on uninstall if the path contains spaces.
Worse, since the path is treated as two separate ones (before and after the space), the uninstall script might `rm -rf` other, unrelated directories¹ – so I'd say this is quite an urgent fix!

___

¹ if the users `Tim` and `Tim Scott` exist, `uninstall.sh` runs `rm -rf /c/Users/Tim Scott/pam_wsl_hello` and boom, say goodbye to Tim's home directory!